### PR TITLE
Set custom label and key

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,5 @@ handleOnChange={(selected) => {
 - `placeholder` - default value is "Nothing selected"
 - `buttonClass` - you can specify a css class for button. Default is "btn-light"
 - `placeholderMultipleChecked` - you can specify a placeholder that will be used if more than one option is selected at the same time. For example: "Multiple selected"
+- `getOptionKey` - specify custom key property of object
+- `getOptionLabel` - specify custom label property of object

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-import React from "react";
 import PropTypes from "prop-types";
+import React from "react";
 
 class DropdownMultiselect extends React.Component {
   constructor(props) {
@@ -10,6 +10,8 @@ class DropdownMultiselect extends React.Component {
       showDropdown: false,
       selected: this.props.selected,
       options: [],
+      optionLabel: this.props.optionLabel,
+      optionKey: this.props.optionKey
     };
   }
 
@@ -22,17 +24,22 @@ class DropdownMultiselect extends React.Component {
     }
 
     if (typeof this.props.options[0] === "object") {
+      let optionsArray = [];
       this.props.options.map((value, index) => {
-        if (value.key === undefined || value.label === undefined) {
-          console.log(
-            "React Dropdown Multiselect Error: options is not well formatted. Please check documentation."
-          );
-          return;
+        let key = value;
+        if (this.props.getOptionKey !== null) {
+          key = this.props.getOptionKey(value);
         }
+
+        let label = value;
+        if (this.props.getOptionLabel !== null) {
+          label = this.props.getOptionLabel(value);
+        }
+        optionsArray.push({ key: key, label: label });
       });
 
       this.setState({
-        options: this.props.options,
+        options: optionsArray,
       });
     }
 
@@ -219,6 +226,8 @@ DropdownMultiselect.propTypes = {
   options: PropTypes.array.isRequired,
   name: PropTypes.string.isRequired,
   showSelectToggle: PropTypes.bool,
+  getOptionKey: PropTypes.string,
+  getOptionLabel: PropTypes.string,
 };
 
 DropdownMultiselect.defaultProps = {
@@ -227,6 +236,8 @@ DropdownMultiselect.defaultProps = {
   placeholderMultipleChecked: null,
   selected: [],
   showSelectToggle: true,
+  getOptionKey: null,
+  getOptionLabel: null,
 };
 
 export default DropdownMultiselect;


### PR DESCRIPTION
I had some trouble-shootings with my key-value option. My structure differs from your suggested `[{key: "", label: ""}]` structure. That's why I integrated two new props in order to specify your own label and key of the passed object array:

* getOptionKey(value: T): string
* getOptionLabel(value: T): string

T is the value of the option array. I'm looking forward to hear your answer.

Cheers
Stefan